### PR TITLE
 test(#62): Cria teste unitario para rota GET reports GetReportsUseCase e GetReportsController

### DIFF
--- a/tests/factories/ReportsFactory.ts
+++ b/tests/factories/ReportsFactory.ts
@@ -1,0 +1,58 @@
+import type { ReportSummaryResponse, ReportsListResponse } from '../../src/modules/reports/dtos/ReportResponseDTO';
+
+import type { ReportsRepository } from '../../src/modules/reports/repositories/ReportsRepository';
+import { vi } from 'vitest';
+
+export class ReportsFactory {
+  static createReportSummary(overrides?: Partial<ReportSummaryResponse>): ReportSummaryResponse {
+    const defaultReport: ReportSummaryResponse = {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      tipoDenuncia: 'PARTIDA_ESPECIFICA',
+      descricao: 'Denúncia de manipulação de resultado em partida',
+      pontualOuDisseminado: 'PONTUAL',
+      frequencia: 'ISOLADO',
+      dataDenuncia: '2024-01-01T10:00:00.000Z',
+      municipio: 'São Paulo',
+      uf: 'SP',
+      totalPessoas: 3,
+      totalClubes: 2,
+      totalEvidencias: 5,
+    };
+
+    return { ...defaultReport, ...overrides };
+  }
+
+  static createReportsList(overrides?: Partial<ReportsListResponse>): ReportsListResponse {
+    const defaultList: ReportsListResponse = {
+      reports: [
+        ReportsFactory.createReportSummary(),
+        ReportsFactory.createReportSummary({
+          id: '223e4567-e89b-12d3-a456-426614174001',
+          tipoDenuncia: 'ESQUEMA_DE_MANIPULACAO',
+          descricao: 'Esquema de apostas ilegais',
+          municipio: 'Rio de Janeiro',
+          uf: 'RJ',
+        }),
+      ],
+      pagination: {
+        page: 1,
+        pageSize: 10,
+        total: 2,
+        totalPages: 1,
+      },
+    };
+
+    return { ...defaultList, ...overrides };
+  }
+
+  static createReportsRepositoryMock(): ReportsRepository {
+    return {
+      create: vi.fn(),
+      findById: vi.fn(),
+      findMany: vi.fn(),
+      updateStatus: vi.fn(),
+      exists: vi.fn(),
+      findClubeByName: vi.fn(),
+    };
+  }
+}

--- a/tests/modules/reports/controllers/GetReportsController.spec.ts
+++ b/tests/modules/reports/controllers/GetReportsController.spec.ts
@@ -1,0 +1,410 @@
+import type { TypedRequest, TypedResponse } from '../../../../src/shared/patterns/Controller';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GetReportsController } from '../../../../src/modules/reports/controllers/GetReportsController';
+import { ReportsFactory } from '../../../factories/ReportsFactory';
+import type { ReportsListResponseSchemaType } from '../../../../src/modules/reports/dtos/ReportResponseDTO';
+import { buildGetReportsUseCase } from '../../../../src/modules/reports/factories/ReportsUseCaseFactory';
+
+// Mock do buildGetReportsUseCase
+vi.mock('../../../../src/modules/reports/factories/ReportsUseCaseFactory', () => ({
+  buildGetReportsUseCase: vi.fn(),
+}));
+
+
+describe('GetReportsController', () => {
+  let controller: GetReportsController;
+  let mockRequest: TypedRequest<any, any, any>;
+  let mockResponse: TypedResponse<{ 200: ReportsListResponseSchemaType }>;
+  let mockUseCase: any;
+
+  beforeEach(() => {
+    // Limpar mocks
+    vi.clearAllMocks();
+
+    controller = new GetReportsController();
+
+    // Mock do use case
+    mockUseCase = {
+      execute: vi.fn(),
+    };
+    (buildGetReportsUseCase as any).mockReturnValue(mockUseCase);
+
+    // Mock da request
+    mockRequest = {
+      query: {},
+      params: {},
+      body: {},
+    } as any;
+
+    // Mock da response
+    mockResponse = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+    } as any;
+  });
+
+  describe('Extração de parâmetros', () => {
+    it('deve extrair page e pageSize da query', async () => {
+      const mockResult = ReportsFactory.createReportsList();
+      mockUseCase.execute.mockResolvedValue(mockResult);
+
+      mockRequest.query = {
+        page: 2,
+        pageSize: 20,
+      };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(mockUseCase.execute).toHaveBeenCalledWith({
+        page: 2,
+        pageSize: 20,
+        filters: {},
+      });
+    });
+
+    it('deve extrair filtros da query', async () => {
+      const mockResult = ReportsFactory.createReportsList();
+      mockUseCase.execute.mockResolvedValue(mockResult);
+
+      mockRequest.query = {
+        page: 1,
+        pageSize: 10,
+        tipoDenuncia: 'PARTIDA_ESPECIFICA',
+        uf: 'SP',
+        municipio: 'São Paulo',
+      };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(mockUseCase.execute).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: {
+          tipoDenuncia: 'PARTIDA_ESPECIFICA',
+          uf: 'SP',
+          municipio: 'São Paulo',
+        },
+      });
+    });
+
+    it('deve extrair filtros de frequência e pontualOuDisseminado', async () => {
+      const mockResult = ReportsFactory.createReportsList();
+      mockUseCase.execute.mockResolvedValue(mockResult);
+
+      mockRequest.query = {
+        page: 1,
+        pageSize: 10,
+        frequencia: 'FREQUENTE',
+        pontualOuDisseminado: 'DISSEMINADO',
+      };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(mockUseCase.execute).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: {
+          frequencia: 'FREQUENTE',
+          pontualOuDisseminado: 'DISSEMINADO',
+        },
+      });
+    });
+
+    it('deve extrair filtros de data', async () => {
+      const mockResult = ReportsFactory.createReportsList();
+      mockUseCase.execute.mockResolvedValue(mockResult);
+
+      mockRequest.query = {
+        page: 1,
+        pageSize: 10,
+        dataInicio: '2024-01-01T00:00:00.000Z',
+        dataFim: '2024-12-31T23:59:59.999Z',
+      };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(mockUseCase.execute).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: {
+          dataInicio: '2024-01-01T00:00:00.000Z',
+          dataFim: '2024-12-31T23:59:59.999Z',
+        },
+      });
+    });
+
+    it('deve extrair termo de busca', async () => {
+      const mockResult = ReportsFactory.createReportsList();
+      mockUseCase.execute.mockResolvedValue(mockResult);
+
+      mockRequest.query = {
+        page: 1,
+        pageSize: 10,
+        termoBusca: 'manipulação',
+      };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(mockUseCase.execute).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: {
+          termoBusca: 'manipulação',
+        },
+      });
+    });
+
+    it('deve separar corretamente page/pageSize dos demais filtros', async () => {
+      const mockResult = ReportsFactory.createReportsList();
+      mockUseCase.execute.mockResolvedValue(mockResult);
+
+      mockRequest.query = {
+        page: 3,
+        pageSize: 25,
+        tipoDenuncia: 'ESQUEMA_DE_MANIPULACAO',
+        uf: 'RJ',
+        frequencia: 'ISOLADO',
+        municipio: 'Rio de Janeiro',
+        termoBusca: 'apostas',
+      };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(mockUseCase.execute).toHaveBeenCalledWith({
+        page: 3,
+        pageSize: 25,
+        filters: {
+          tipoDenuncia: 'ESQUEMA_DE_MANIPULACAO',
+          uf: 'RJ',
+          frequencia: 'ISOLADO',
+          municipio: 'Rio de Janeiro',
+          termoBusca: 'apostas',
+        },
+      });
+    });
+
+    it('deve passar filtros vazios quando apenas page e pageSize são fornecidos', async () => {
+      const mockResult = ReportsFactory.createReportsList();
+      mockUseCase.execute.mockResolvedValue(mockResult);
+
+      mockRequest.query = {
+        page: 1,
+        pageSize: 10,
+      };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(mockUseCase.execute).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: {},
+      });
+    });
+  });
+
+  describe('Chamada do Use Case', () => {
+    it('deve chamar buildGetReportsUseCase para obter o use case', async () => {
+      const mockResult = ReportsFactory.createReportsList();
+      mockUseCase.execute.mockResolvedValue(mockResult);
+
+      mockRequest.query = { page: 1, pageSize: 10 };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(buildGetReportsUseCase).toHaveBeenCalledTimes(1);
+    });
+
+    it('deve executar o use case com os parâmetros corretos', async () => {
+      const mockResult = ReportsFactory.createReportsList();
+      mockUseCase.execute.mockResolvedValue(mockResult);
+
+      mockRequest.query = {
+        page: 2,
+        pageSize: 20,
+        uf: 'SP',
+      };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(mockUseCase.execute).toHaveBeenCalledTimes(1);
+      expect(mockUseCase.execute).toHaveBeenCalledWith({
+        page: 2,
+        pageSize: 20,
+        filters: { uf: 'SP' },
+      });
+    });
+  });
+
+  describe('Resposta', () => {
+    it('deve retornar status 200 com os dados do use case', async () => {
+      const mockResult = ReportsFactory.createReportsList();
+      mockUseCase.execute.mockResolvedValue(mockResult);
+
+      mockRequest.query = { page: 1, pageSize: 10 };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.send).toHaveBeenCalledWith(mockResult);
+    });
+
+    it('deve retornar lista vazia quando não há relatórios', async () => {
+      const emptyResult = ReportsFactory.createReportsList({
+        reports: [],
+        pagination: {
+          page: 1,
+          pageSize: 10,
+          total: 0,
+          totalPages: 0,
+        },
+      });
+      mockUseCase.execute.mockResolvedValue(emptyResult);
+
+      mockRequest.query = { page: 1, pageSize: 10 };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.send).toHaveBeenCalledWith(emptyResult);
+    });
+
+    it('deve retornar dados de paginação corretos', async () => {
+      const mockResult = ReportsFactory.createReportsList({
+        pagination: {
+          page: 2,
+          pageSize: 20,
+          total: 50,
+          totalPages: 3,
+        },
+      });
+      mockUseCase.execute.mockResolvedValue(mockResult);
+
+      mockRequest.query = { page: 2, pageSize: 20 };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(mockResponse.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pagination: {
+            page: 2,
+            pageSize: 20,
+            total: 50,
+            totalPages: 3,
+          },
+        })
+      );
+    });
+
+    it('deve retornar lista de relatórios com estrutura correta', async () => {
+      const mockReports = [
+        ReportsFactory.createReportSummary(),
+        ReportsFactory.createReportSummary({
+          id: '456',
+          tipoDenuncia: 'ESQUEMA_DE_MANIPULACAO',
+        }),
+      ];
+
+      const mockResult = ReportsFactory.createReportsList({
+        reports: mockReports,
+        pagination: {
+          page: 1,
+          pageSize: 10,
+          total: 2,
+          totalPages: 1,
+        },
+      });
+
+      mockUseCase.execute.mockResolvedValue(mockResult);
+      mockRequest.query = { page: 1, pageSize: 10 };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(mockResponse.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reports: expect.arrayContaining([
+            expect.objectContaining({ id: expect.any(String) }),
+          ]),
+        })
+      );
+    });
+  });
+
+  describe('Tratamento de erros', () => {
+    it('deve propagar erro do use case', async () => {
+      const error = new Error('Erro no use case');
+      mockUseCase.execute.mockRejectedValue(error);
+
+      mockRequest.query = { page: 1, pageSize: 10 };
+
+      await expect(controller.handle(mockRequest, mockResponse)).rejects.toThrow(
+        'Erro no use case'
+      );
+
+      expect(mockResponse.status).not.toHaveBeenCalled();
+      expect(mockResponse.send).not.toHaveBeenCalled();
+    });
+
+    it('deve propagar erro de validação do use case', async () => {
+      const validationError = new Error('Parâmetros inválidos');
+      mockUseCase.execute.mockRejectedValue(validationError);
+
+      mockRequest.query = { page: -1, pageSize: 10 };
+
+      await expect(controller.handle(mockRequest, mockResponse)).rejects.toThrow(
+        'Parâmetros inválidos'
+      );
+    });
+
+    it('deve propagar erro do repositório através do use case', async () => {
+      const dbError = new Error('Erro no banco de dados');
+      mockUseCase.execute.mockRejectedValue(dbError);
+
+      mockRequest.query = { page: 1, pageSize: 10 };
+
+      await expect(controller.handle(mockRequest, mockResponse)).rejects.toThrow(
+        'Erro no banco de dados'
+      );
+    });
+  });
+
+  describe('Integração controller-usecase', () => {
+    it('deve processar requisição completa com múltiplos filtros', async () => {
+      const mockResult = ReportsFactory.createReportsList();
+      mockUseCase.execute.mockResolvedValue(mockResult);
+
+      mockRequest.query = {
+        page: 1,
+        pageSize: 50,
+        tipoDenuncia: 'PARTIDA_ESPECIFICA',
+        frequencia: 'FREQUENTE',
+        pontualOuDisseminado: 'DISSEMINADO',
+        uf: 'MG',
+        municipio: 'Belo Horizonte',
+        dataInicio: '2024-01-01T00:00:00.000Z',
+        dataFim: '2024-06-30T23:59:59.999Z',
+        termoBusca: 'futebol',
+      };
+
+      await controller.handle(mockRequest, mockResponse);
+
+      expect(buildGetReportsUseCase).toHaveBeenCalled();
+      expect(mockUseCase.execute).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 50,
+        filters: {
+          tipoDenuncia: 'PARTIDA_ESPECIFICA',
+          frequencia: 'FREQUENTE',
+          pontualOuDisseminado: 'DISSEMINADO',
+          uf: 'MG',
+          municipio: 'Belo Horizonte',
+          dataInicio: '2024-01-01T00:00:00.000Z',
+          dataFim: '2024-06-30T23:59:59.999Z',
+          termoBusca: 'futebol',
+        },
+      });
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.send).toHaveBeenCalledWith(mockResult);
+    });
+  });
+});

--- a/tests/modules/reports/usecases/GetReportsUseCase.spec.ts
+++ b/tests/modules/reports/usecases/GetReportsUseCase.spec.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetReportsUseCase } from '../../../../src/modules/reports/usecases/GetReportsUseCase';
+import { ReportsFactory } from '../../../factories/ReportsFactory';
+import type { ReportsRepository } from '../../../../src/modules/reports/repositories/ReportsRepository';
+
+describe('GetReportsUseCase', () => {
+  let mockReportsRepository: ReportsRepository;
+  let useCase: GetReportsUseCase;
+
+  beforeEach(() => {
+    mockReportsRepository = ReportsFactory.createReportsRepositoryMock();
+    useCase = new GetReportsUseCase(mockReportsRepository);
+  });
+
+  describe('Paginação', () => {
+    it('deve retornar relatórios com paginação padrão quando não especificada', async () => {
+      const mockReports = [ReportsFactory.createReportSummary()];
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: mockReports,
+        total: 1,
+      });
+
+      const result = await useCase.execute({
+        page: undefined as any,
+        pageSize: undefined as any,
+        filters: {},
+      });
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: {},
+      });
+      expect(result.reports).toEqual(mockReports);
+      expect(result.pagination).toEqual({
+        page: 1,
+        pageSize: 10,
+        total: 1,
+        totalPages: 1,
+      });
+    });
+
+    it('deve validar e usar parâmetros de paginação fornecidos', async () => {
+      const mockReports = [ReportsFactory.createReportSummary()];
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: mockReports,
+        total: 50,
+      });
+
+      const result = await useCase.execute({
+        page: 2,
+        pageSize: 20,
+        filters: {},
+      });
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledWith({
+        page: 2,
+        pageSize: 20,
+        filters: {},
+      });
+      expect(result.pagination).toEqual({
+        page: 2,
+        pageSize: 20,
+        total: 50,
+        totalPages: 3,
+      });
+    });
+
+    it('deve garantir que page seja no mínimo 1', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 0,
+      });
+
+      await useCase.execute({
+        page: 0,
+        pageSize: 10,
+        filters: {},
+      });
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: {},
+      });
+    });
+
+    it('deve garantir que page seja no mínimo 1 quando negativo', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 0,
+      });
+
+      await useCase.execute({
+        page: -5,
+        pageSize: 10,
+        filters: {},
+      });
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: {},
+      });
+    });
+
+    it('deve usar pageSize padrão 10 quando pageSize for 0', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 0,
+      });
+
+      await useCase.execute({
+        page: 1,
+        pageSize: 0,
+        filters: {},
+      });
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: {},
+      });
+    });
+
+    it('deve garantir que pageSize seja no mínimo 1 quando negativo', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 0,
+      });
+
+      await useCase.execute({
+        page: 1,
+        pageSize: -5,
+        filters: {},
+      });
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 1,
+        filters: {},
+      });
+    });
+
+    it('deve limitar pageSize ao máximo de 100', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 0,
+      });
+
+      await useCase.execute({
+        page: 1,
+        pageSize: 150,
+        filters: {},
+      });
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 100,
+        filters: {},
+      });
+    });
+
+    it('deve calcular totalPages corretamente', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 25,
+      });
+
+      const result = await useCase.execute({
+        page: 1,
+        pageSize: 10,
+        filters: {},
+      });
+
+      expect(result.pagination.totalPages).toBe(3);
+    });
+
+    it('deve retornar totalPages = 0 quando não há relatórios', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 0,
+      });
+
+      const result = await useCase.execute({
+        page: 1,
+        pageSize: 10,
+        filters: {},
+      });
+
+      expect(result.pagination.totalPages).toBe(0);
+    });
+  });
+
+  describe('Filtros', () => {
+    it('deve passar filtros vazios quando não especificados', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 0,
+      });
+
+      await useCase.execute({
+        page: 1,
+        pageSize: 10,
+        filters: undefined as any,
+      });
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: {},
+      });
+    });
+
+    it('deve passar filtros de tipoDenuncia para o repositório', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 0,
+      });
+
+      await useCase.execute({
+        page: 1,
+        pageSize: 10,
+        filters: { tipoDenuncia: 'PARTIDA_ESPECIFICA' },
+      });
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: { tipoDenuncia: 'PARTIDA_ESPECIFICA' },
+      });
+    });
+
+    it('deve passar filtros de localização (uf e município) para o repositório', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 0,
+      });
+
+      await useCase.execute({
+        page: 1,
+        pageSize: 10,
+        filters: { uf: 'SP', municipio: 'São Paulo' },
+      });
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: { uf: 'SP', municipio: 'São Paulo' },
+      });
+    });
+
+    it('deve passar filtros de data para o repositório', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 0,
+      });
+
+      await useCase.execute({
+        page: 1,
+        pageSize: 10,
+        filters: {
+          dataInicio: '2024-01-01',
+          dataFim: '2024-12-31',
+        },
+      });
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: {
+          dataInicio: '2024-01-01',
+          dataFim: '2024-12-31',
+        },
+      });
+    });
+
+    it('deve passar filtro de termo de busca para o repositório', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 0,
+      });
+
+      await useCase.execute({
+        page: 1,
+        pageSize: 10,
+        filters: { termoBusca: 'manipulação' },
+      });
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: { termoBusca: 'manipulação' },
+      });
+    });
+
+    it('deve passar múltiplos filtros combinados para o repositório', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 0,
+      });
+
+      await useCase.execute({
+        page: 1,
+        pageSize: 10,
+        filters: {
+          tipoDenuncia: 'ESQUEMA_DE_MANIPULACAO',
+          uf: 'RJ',
+          frequencia: 'FREQUENTE',
+          pontualOuDisseminado: 'DISSEMINADO',
+        },
+      });
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledWith({
+        page: 1,
+        pageSize: 10,
+        filters: {
+          tipoDenuncia: 'ESQUEMA_DE_MANIPULACAO',
+          uf: 'RJ',
+          frequencia: 'FREQUENTE',
+          pontualOuDisseminado: 'DISSEMINADO',
+        },
+      });
+    });
+  });
+
+  describe('Resposta', () => {
+    it('deve retornar lista de relatórios formatada corretamente', async () => {
+      const mockReports = [
+        ReportsFactory.createReportSummary(),
+        ReportsFactory.createReportSummary({ id: '456' }),
+      ];
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: mockReports,
+        total: 2,
+      });
+
+      const result = await useCase.execute({
+        page: 1,
+        pageSize: 10,
+        filters: {},
+      });
+
+      expect(result.reports).toEqual(mockReports);
+      expect(result.reports).toHaveLength(2);
+      expect(result.pagination).toEqual({
+        page: 1,
+        pageSize: 10,
+        total: 2,
+        totalPages: 1,
+      });
+    });
+
+    it('deve retornar lista vazia quando não há relatórios', async () => {
+      mockReportsRepository.findMany = vi.fn().mockResolvedValue({
+        reports: [],
+        total: 0,
+      });
+
+      const result = await useCase.execute({
+        page: 1,
+        pageSize: 10,
+        filters: {},
+      });
+
+      expect(result.reports).toEqual([]);
+      expect(result.reports).toHaveLength(0);
+      expect(result.pagination.total).toBe(0);
+    });
+  });
+
+  describe('Erros', () => {
+    it('deve propagar erro quando o repositório falhar', async () => {
+      const error = new Error('Erro no banco de dados');
+      mockReportsRepository.findMany = vi.fn().mockRejectedValue(error);
+
+      await expect(
+        useCase.execute({
+          page: 1,
+          pageSize: 10,
+          filters: {},
+        })
+      ).rejects.toThrow('Erro no banco de dados');
+
+      expect(mockReportsRepository.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('deve propagar erro de conexão do repositório', async () => {
+      const connectionError = new Error('Falha na conexão com o banco');
+      mockReportsRepository.findMany = vi.fn().mockRejectedValue(connectionError);
+
+      await expect(
+        useCase.execute({
+          page: 1,
+          pageSize: 10,
+          filters: {},
+        })
+      ).rejects.toThrow('Falha na conexão com o banco');
+    });
+  });
+});


### PR DESCRIPTION
thiagovivan@MacThiago plataforma-civica-backend % npm test -- GetReportsUseCase

> backend-denuncias-de-apostas-pf@1.0.0 test
> vitest run GetReportsUseCase


 RUN  v3.2.4 /Users/thiagovivan/faculdade/EPS/plataforma-civica-backend

 ✓ tests/modules/reports/usecases/GetReportsUseCase.spec.ts (19 tests) 13ms
   ✓ GetReportsUseCase > Paginação > deve retornar relatórios com paginação padrão quando não especificada 4ms
   ✓ GetReportsUseCase > Paginação > deve validar e usar parâmetros de paginação fornecidos 1ms
   ✓ GetReportsUseCase > Paginação > deve garantir que page seja no mínimo 1 0ms
   ✓ GetReportsUseCase > Paginação > deve garantir que page seja no mínimo 1 quando negativo 0ms
   ✓ GetReportsUseCase > Paginação > deve usar pageSize padrão 10 quando pageSize for 0 0ms
   ✓ GetReportsUseCase > Paginação > deve garantir que pageSize seja no mínimo 1 quando negativo 0ms
   ✓ GetReportsUseCase > Paginação > deve limitar pageSize ao máximo de 100 0ms
   ✓ GetReportsUseCase > Paginação > deve calcular totalPages corretamente 0ms
   ✓ GetReportsUseCase > Paginação > deve retornar totalPages = 0 quando não há relatórios 0ms
   ✓ GetReportsUseCase > Filtros > deve passar filtros vazios quando não especificados 0ms
   ✓ GetReportsUseCase > Filtros > deve passar filtros de tipoDenuncia para o repositório 0ms
   ✓ GetReportsUseCase > Filtros > deve passar filtros de localização (uf e município) para o repositório 0ms
   ✓ GetReportsUseCase > Filtros > deve passar filtros de data para o repositório 0ms
   ✓ GetReportsUseCase > Filtros > deve passar filtro de termo de busca para o repositório 0ms
   ✓ GetReportsUseCase > Filtros > deve passar múltiplos filtros combinados para o repositório 0ms
   ✓ GetReportsUseCase > Resposta > deve retornar lista de relatórios formatada corretamente 1ms
   ✓ GetReportsUseCase > Resposta > deve retornar lista vazia quando não há relatórios 0ms
   ✓ GetReportsUseCase > Erros > deve propagar erro quando o repositório falhar 2ms
   ✓ GetReportsUseCase > Erros > deve propagar erro de conexão do repositório 0ms

 Test Files  1 passed (1)
      Tests  19 passed (19)
   Start at  16:36:27
   Duration  407ms (transform 64ms, setup 0ms, collect 53ms, tests 13ms, environment 0ms, prepare 103ms)

thiagovivan@MacThiago plataforma-civica-backend % npm test -- GetReportsController

> backend-denuncias-de-apostas-pf@1.0.0 test
> vitest run GetReportsController


 RUN  v3.2.4 /Users/thiagovivan/faculdade/EPS/plataforma-civica-backend

 ✓ tests/modules/reports/controllers/GetReportsController.spec.ts (17 tests) 10ms
   ✓ GetReportsController > Extração de parâmetros > deve extrair page e pageSize da query 3ms
   ✓ GetReportsController > Extração de parâmetros > deve extrair filtros da query 0ms
   ✓ GetReportsController > Extração de parâmetros > deve extrair filtros de frequência e pontualOuDisseminado 0ms
   ✓ GetReportsController > Extração de parâmetros > deve extrair filtros de data 0ms
   ✓ GetReportsController > Extração de parâmetros > deve extrair termo de busca 0ms
   ✓ GetReportsController > Extração de parâmetros > deve separar corretamente page/pageSize dos demais filtros 0ms
   ✓ GetReportsController > Extração de parâmetros > deve passar filtros vazios quando apenas page e pageSize são fornecidos 0ms
   ✓ GetReportsController > Chamada do Use Case > deve chamar buildGetReportsUseCase para obter o use case 0ms
   ✓ GetReportsController > Chamada do Use Case > deve executar o use case com os parâmetros corretos 0ms
   ✓ GetReportsController > Resposta > deve retornar status 200 com os dados do use case 0ms
   ✓ GetReportsController > Resposta > deve retornar lista vazia quando não há relatórios 0ms
   ✓ GetReportsController > Resposta > deve retornar dados de paginação corretos 1ms
   ✓ GetReportsController > Resposta > deve retornar lista de relatórios com estrutura correta 0ms
   ✓ GetReportsController > Tratamento de erros > deve propagar erro do use case 1ms
   ✓ GetReportsController > Tratamento de erros > deve propagar erro de validação do use case 0ms
   ✓ GetReportsController > Tratamento de erros > deve propagar erro do repositório através do use case 0ms
   ✓ GetReportsController > Integração controller-usecase > deve processar requisição completa com múltiplos filtros 0ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
   Start at  16:36:31
   Duration  327ms (transform 55ms, setup 0ms, collect 58ms, tests 10ms, environment 0ms, prepare 67ms)
